### PR TITLE
Make "format" param optional

### DIFF
--- a/lib/rack/route.rb
+++ b/lib/rack/route.rb
@@ -22,6 +22,7 @@ module Rack
       @pattern = pattern
       @app = app
       @constraints = options && options[:constraints]
+      @format = options && (options[:format].nil? || options[:format])
       @name = options && options[:as]
     end
 
@@ -43,7 +44,9 @@ module Rack
         else
           pattern
         end
-        p + '(?:\.(?<format>.*))?'
+
+        p += '(?:\.(?<format>.*))?' if @format
+        p
       end
       Regexp.new("\\A#{src}\\Z")
     end

--- a/test/route_test.rb
+++ b/test/route_test.rb
@@ -57,6 +57,13 @@ class RouteTest < Test::Unit::TestCase
       Rack::Route.new('GET', "/", app))
   end
 
+  def test_no_format
+    r = route('GET', "/:id", :format => false)
+
+    assert_equal({ :id => "a" },   r.match('GET', "/a"))
+    assert_equal({ :id => "a.b" }, r.match('GET', "/a.b"))
+  end
+
   private
   def route(request_method, path, options={})
     Rack::Route.new(request_method, path, lambda{|env| [200, {}, [""]] }, options)


### PR DESCRIPTION
Fixes #1 by adding a new option "format" that defaults to the existing behavior.
